### PR TITLE
Make beaver tail buffering configurable

### DIFF
--- a/beaver/__init__.py
+++ b/beaver/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '36.2.1-affirm-2.1'
+__version__ = '36.2.1-affirm-2.2'

--- a/beaver/config.py
+++ b/beaver/config.py
@@ -221,6 +221,15 @@ class BeaverConfig():
             'aws_kms_secret_key': None,
             'aws_kms_key_ids': None,
             'aws_kms_encryption_context': None,
+
+            # Size in bytes that Tail process will load into memory and proccess at a time from file
+            'file_read_blocksize': 4096,
+
+            # If set, Tail processes will buffer data in memory until up to this many lines are read
+            # or buffered_lines_max_size is reached, or buffered_lines_max_seconds is exceeded, whichever comes first.
+            'buffered_lines_max_lines': 0,
+            'buffered_lines_max_bytes': 0,
+            'buffered_lines_max_seconds': 0
         }
 
         self._configfile = args.config
@@ -367,7 +376,10 @@ class BeaverConfig():
                 'kafka_batch_t',
                 'kafka_ack_timeout',
                 'number_of_consumer_processes',
-                'ignore_old_files'
+                'ignore_old_files',
+                'buffered_lines_max_lines',
+                'buffered_lines_max_bytes',
+                'buffered_lines_max_seconds'
             ]
             for key in require_int:
                 if config[key] is not None:

--- a/tests/test_tail.py
+++ b/tests/test_tail.py
@@ -7,6 +7,8 @@ else:
 
 import mock
 import tempfile
+import time
+from datetime import datetime
 
 from beaver.config import BeaverConfig
 from beaver.worker.tail import  Tail
@@ -18,9 +20,10 @@ class TestTail(unittest.TestCase):
         self.sincedb_path = tempfile.NamedTemporaryFile(delete=True).name
         self.filename = tempfile.NamedTemporaryFile(delete=True).name
 
-        beaver_config = self._get_config()
-        beaver_config.set('sincedb_path', self.sincedb_path)
-        self.tail = Tail(self.filename, None, beaver_config=beaver_config)
+        self.beaver_config = self._get_config()
+        self.beaver_config.set('sincedb_path', self.sincedb_path)
+        self.callback = mock.Mock()
+        self.tail = Tail(self.filename, self.callback, beaver_config=self.beaver_config)
 
     def _get_config(self, **kwargs):
         empty_conf = tempfile.NamedTemporaryFile(delete=True)
@@ -48,8 +51,141 @@ class TestTail(unittest.TestCase):
         results = self._test_close_parameterized_remove_db_entry(True)
         self.assertEquals(len(results), 0)
 
-
     def test_close_without_remove_db_entry(self):
         # Without remove entry, results should be 1.
         results = self._test_close_parameterized_remove_db_entry(False)
         self.assertEquals(len(results), 1)
+
+    def test_runtail_defaults(self):
+        self.tail._update_file()
+        lines = ['test', 'test2']
+        with open(self.filename, 'a') as logfile:
+            # Create the file
+            logfile.write('')
+            # Update the file tracking internally
+            self.tail._update_file()
+            # Write to the file
+            logfile.write('\n'.join(lines) + '\n')
+
+        start_time = time.time()
+        self.tail._sincedb_update_position = mock.Mock(wraps=self.tail._sincedb_update_position)
+        self.tail._run_pass()
+        # Should be super fast
+        self.assertGreaterEqual(0.1, time.time() - start_time)
+
+        self.callback.assert_called_once()
+        self.assertEqual(lines, self.callback.call_args[0][0][1]['lines'])
+        self.assertEqual(2, self.tail._sincedb_update_position.call_count)
+
+        # check sincedb is correct
+        self.tail._sincedb_update_position(force_update=True)
+        self.assertEqual(2, self.tail._sincedb_start_position())
+
+    def test_runtail_nolines(self):
+        with open(self.filename, 'a') as logfile:
+            # Create the file
+            logfile.write('')
+            # Update the file tracking internally
+            self.tail._update_file()
+
+        self.tail._sincedb_update_position = mock.Mock(wraps=self.tail._sincedb_update_position)
+        start_time = time.time()
+        self.tail._run_pass()
+        # Should be super fast
+        self.assertGreaterEqual(0.1, time.time() - start_time)
+        self.callback.assert_not_called()
+        self.tail._sincedb_update_position.assert_called_once()
+
+        # check sincedb is correct
+        self.tail._sincedb_update_position(force_update=True)
+        self.assertEqual(0, self.tail._sincedb_start_position())
+
+    def test_runtail_with_flush_buffer_lines(self):
+        self.tail._update_file()
+        lines = ['test', 'test2']
+        flush_seconds = 1
+        self.beaver_config.set('buffered_lines_max_lines', 2)
+        self.beaver_config.set('buffered_lines_max_bytes', 10000)
+        self.beaver_config.set('buffered_lines_max_seconds', flush_seconds)
+
+        self.tail = Tail(self.filename, self.callback, beaver_config=self.beaver_config)
+
+        with open(self.filename, 'a') as logfile:
+            # Create the file
+            logfile.write('')
+            # Update the file tracking internally
+            self.tail._update_file()
+            # Write to the file
+            logfile.write('\n'.join(lines) + '\n')
+
+        self.tail._sincedb_update_position = mock.Mock(wraps=self.tail._sincedb_update_position)
+        start_time = datetime.utcnow()
+        self.tail._run_pass()
+        # Should be super fast
+        called_time = datetime.strptime(self.callback.call_args[0][0][1]['timestamp'],
+                                        '%Y-%m-%dT%H:%M:%S.%fZ')
+        self.assertLessEqual((called_time - start_time).total_seconds(), 0.1)
+
+        self.callback.assert_called_once()
+        self.assertEqual(lines, self.callback.call_args[0][0][1]['lines'])
+
+        self.callback.reset_mock()
+        lines = ['test3']
+        with open(self.filename, 'a') as logfile:
+            # Write to the file
+            logfile.write('\n'.join(lines) + '\n')
+
+        start_time = datetime.utcnow()
+        self.tail._run_pass()
+        called_time = datetime.strptime(self.callback.call_args[0][0][1]['timestamp'],
+                                        '%Y-%m-%dT%H:%M:%S.%fZ')
+        self.assertLessEqual(flush_seconds, (called_time - start_time).total_seconds())
+        self.assertEqual(3, self.tail._sincedb_update_position.call_count)
+
+        # check sincedb is correct
+        self.tail._sincedb_update_position(force_update=True)
+        self.assertEqual(3, self.tail._sincedb_start_position())
+
+    def test_runntail_with_flush_buffer_bytes(self):
+        self.tail._update_file()
+        lines = ['test', 'test2']
+        flush_seconds = 1
+        self.beaver_config.set('buffered_lines_max_lines', 100)
+        self.beaver_config.set('buffered_lines_max_bytes', 8)
+        self.beaver_config.set('buffered_lines_max_seconds', flush_seconds)
+
+        self.tail = Tail(self.filename, self.callback, beaver_config=self.beaver_config)
+
+        with open(self.filename, 'a') as logfile:
+            # Create the file
+            logfile.write('')
+            # Update the file tracking internally
+            self.tail._update_file()
+            # Write to the file
+            logfile.write('\n'.join(lines) + '\n')
+
+        self.tail._sincedb_update_position = mock.Mock(wraps=self.tail._sincedb_update_position)
+        start_time = datetime.utcnow()
+        self.tail._run_pass()
+        self.callback.assert_called_once()
+        self.assertEqual(lines, self.callback.call_args[0][0][1]['lines'])
+        called_time = datetime.strptime(self.callback.call_args[0][0][1]['timestamp'],
+                                        '%Y-%m-%dT%H:%M:%S.%fZ')
+        self.assertLessEqual((called_time - start_time).total_seconds(), 0.1)
+
+        self.callback.reset_mock()
+        lines = ['a', 'b']
+        with open(self.filename, 'a') as logfile:
+            # Write to the file
+            logfile.write('\n'.join(lines) + '\n')
+
+        start_time = datetime.utcnow()
+        self.tail._run_pass()
+        called_time = datetime.strptime(self.callback.call_args[0][0][1]['timestamp'],
+                                        '%Y-%m-%dT%H:%M:%S.%fZ')
+        self.assertLessEqual(flush_seconds, (called_time - start_time).total_seconds())
+        self.assertEqual(3, self.tail._sincedb_update_position.call_count)
+
+        # check sincedb is correct
+        self.tail._sincedb_update_position(force_update=True)
+        self.assertEqual(4, self.tail._sincedb_start_position())


### PR DESCRIPTION
@knguyen142 @mahendra 

Making beaver tail buffering as a new configurable setting.

This enables tail to buffer lines in memory up to a certain line limit or byte limit before flushing. If the limit is not reached within bufferd_lines_max_seconds, the buffer gets flushed then.

The end result here is that puts to Kinesis will have larger batches and less network calls per second, so better throughput and less risk of premature throttling from Kinesis service.

Without the new settings set in the config, beaver will run as it does now.